### PR TITLE
envセットのタイミングを変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update && apt remove -y nginx && apt install -y nginx && apt clean
 COPY ./file/mu-web.conf /etc/nginx/conf.d/
 
 # start next
-ENV NODE_ENV=production
+# ENV NODE_ENV=production
 WORKDIR /var/www
 COPY ./app app/
 RUN cd app && npm install && npm run export

--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,7 @@
     "prestart": "npm run build",
     "start": "next start -p 8000",
     "preexport": "npm run build",
-    "export": "next export",
+    "export": "NODE_ENV=production next export",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
`npm install`する前に`NODE_ENV=production`すると
`devDependencies`が読み込まれないので、export時に修正