### PR TITLE
docker buildをgithub actionsに移行

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   build:
     name: Build Docker Image
-    runs-on: &build-image ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,6 +1,6 @@
 name: mu-web-workflow
 
-on: push
+on: pull_request
 
 jobs:
   build:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,23 @@
+name: mu-web-workflow
+
+jobs:
+  build:
+    name: Build Docker Image
+    runs-on: &build-image ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build docker image
+        run: docker build -t mu-web .
+      - name: Test docker run
+        run: |
+          docker run -d --name mu-web-container mu-web
+          docker exec mu-web-container curl --retry 10 --retry-connrefused http://localhost/status | grep 'Connection OK'
+      - name: Save docker image
+        run: docker image save mu-web > ./mu-web.tar
+      - name: Archive docker image
+        uses: actions/upload-artifact@v3
+        with:
+          name: mu-web-docker-image
+          path: ./mu-web.tar
+          retention-days: 5

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,5 +1,7 @@
 name: mu-web-workflow
 
+on: push
+
 jobs:
   build:
     name: Build Docker Image


### PR DESCRIPTION
## Summary
circleciからgithub actionsへの移行の一環として、まずはdocker build出来るようにする。